### PR TITLE
support building a static library

### DIFF
--- a/atspi/meson.build
+++ b/atspi/meson.build
@@ -67,7 +67,7 @@ atspi_enums = gnome.mkenums('atspi-enum-types',
                             install_header: true)
 atspi_enum_h = atspi_enums[1]
 
-atspi = shared_library('atspi', atspi_sources + atspi_enums,
+atspi = library('atspi', atspi_sources + atspi_enums,
                        version: soversion,
                        soversion: soversion.split('.')[0],
                        include_directories: [ root_inc, registryd_inc ],

--- a/dbind/meson.build
+++ b/dbind/meson.build
@@ -3,12 +3,10 @@ dbind_sources = [
   'dbind-any.c',
 ]
 
-dbind = static_library('dbind', dbind_sources,
-                       include_directories: root_inc,
-                       dependencies: [ libdbus_dep, glib_dep ],
-                       c_args: [ '-DG_LOG_DOMAIN="dbind"' ])
-
-dbind_dep = declare_dependency(link_with: dbind)
+dbind_dep = declare_dependency(sources: dbind_sources,
+                               include_directories: root_inc,
+                               compile_args: [ '-DG_LOG_DOMAIN="dbind"' ],
+                               dependencies: [ libdbus_dep, glib_dep ])
 
 test('dbind-test',
      executable('dbind-test', [ 'dbtest.c', '../atspi/atspi-gmain.c' ],


### PR DESCRIPTION
Change the atspi library definition in meson.build to `library()`
instead of `shared_library()` so that when meson is called with
`--default-library static` a static library is built.

For this to work, also change the `declare_dependency()` in
`dbind/meson.build` to be a list of sources instead of a `link_with:`
`static_library()`.