### PR TITLE
bus-launch: add dbus-broker support

### DIFF
--- a/bus/meson.build
+++ b/bus/meson.build
@@ -31,8 +31,13 @@ configure_file(input: 'at-spi-dbus-bus.service.in',
                install: true,
                install_dir: systemd_user_dir)
 
+launcher_args = [
+             '-DSYSCONFDIR="@0@"'.format(atspi_sysconfdir),
+             '-DDATADIR="@0@"'.format(atspi_datadir),
+           ]
+
 if get_option('dbus_daemon') != 'default'
-  dbus_daemon = get_option('dbus_daemon')
+  launcher_args += '-DDBUS_DAEMON="@0@"'.format(get_option('dbus_daemon'))
 else
   dbus_daemon = find_program('dbus-daemon',
                              '/sbin/dbus-daemon',
@@ -40,16 +45,29 @@ else
                              '/libexec/dbus-daemon',
                              '/usr/libexec/dbus-daemon',
                              '/usr/pkg/bin/dbus-daemon',
-                             required: true).path()
+                             required: false)
+  if dbus_daemon.found()
+    launcher_args += '-DDBUS_DAEMON="@0@"'.format(dbus_daemon.path())
+  endif
+endif
+
+if get_option('dbus_broker') != 'default'
+  launcher_args += '-DDBUS_BROKER="@0@"'.format(get_option('dbus_broker'))
+else
+  dbus_broker = find_program('dbus-broker-launch',
+                             required: false)
+  if dbus_broker.found()
+    launcher_args += '-DDBUS_BROKER="@0@"'.format(dbus_broker.path())
+  endif
+endif
+
+if get_option('default_bus') == 'dbus-broker'
+  launcher_args += '-DWANT_DBUS_BROKER'
 endif
 
 executable('at-spi-bus-launcher', 'at-spi-bus-launcher.c',
            include_directories: [ root_inc, include_directories('.') ],
            dependencies: [ gio_dep, x11_deps ],
-           c_args: [
-             '-DSYSCONFDIR="@0@"'.format(atspi_sysconfdir),
-             '-DDATADIR="@0@"'.format(atspi_datadir),
-             '-DDBUS_DAEMON="@0@"'.format(dbus_daemon),
-           ],
+           c_args: launcher_args,
            install: true,
            install_dir: atspi_libexecdir)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -6,6 +6,15 @@ option('dbus_daemon',
        description: 'The path of the DBus daemon',
        type: 'string',
        value: 'default')
+option('dbus_broker',
+       description: 'The path of the DBus broker',
+       type: 'string',
+       value: 'default')
+option('default_bus',
+       description: 'The default DBus implementation to use',
+       type: 'combo',
+       choices: ['dbus-daemon', 'dbus-broker'],
+       value: 'dbus-daemon')
 option('systemd_user_dir',
        description: 'Location of the systemd user services',
        type: 'string',


### PR DESCRIPTION
This adds optional support to use [dbus-broker](https://github.com/bus1/dbus-broker/wiki) instead of dbus-daemon.

The benefits to at-spi2 should be higher performance and reliability, and to distros using at-spi2 it would give them the possibility to no longer install the dbus-daemon package by default in case they decide to us dbus-broker for their system and user bus.

For more details please see the wiki link above and the commit message.

I have only done basic testing of this, so please consider this a RFC. Any additional testing form someone more familiar with at-spi2 would be very welcome.