### PR TITLE
bus-launch: use __linux__ over __linux

### DIFF
--- a/bus/at-spi-bus-launcher.c
+++ b/bus/at-spi-bus-launcher.c
@@ -25,7 +25,7 @@
 #include <unistd.h>
 #include <string.h>
 #include <signal.h>
-#ifdef __linux
+#ifdef __linux__
 #include <sys/prctl.h>
 #include <sys/socket.h>
 #include <sys/un.h>
@@ -278,7 +278,7 @@ setup_bus_child_daemon (gpointer data)
   close (app->pipefd[1]);
 
   /* On Linux, tell the bus process to exit if this process goes away */
-#ifdef __linux
+#ifdef __linux__
   prctl (PR_SET_PDEATHSIG, 15);
 #endif
 }


### PR DESCRIPTION
The canonical way to check for linux support is '__linux__', not
'__linux'. Particularly, on ppc64le '__linux' is not defined and the
build will fail.

For reference, see:

    https://sourceforge.net/p/predef/wiki/OperatingSystems/